### PR TITLE
fix: ImportError: cannot import name 'Annotated' from 'pydantic.typing'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ grpcio==1.57.0
 grpcio-tools==1.57.0
 hydra-core==1.3.2
 HyperPyYAML==1.2.2
-inflect==6.0.2
+inflect==7.3.1
 librosa==0.10.2
 lightning==2.2.4
 matplotlib==3.7.5


### PR DESCRIPTION
Pydantic v2 is not able to work with inflect 6.0.2. Pydantic v1 is not able to work with gradio >= 4.3.1
So I upgrade inflect and it works.