### PR TITLE
about pretrained_models directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ from cosyvoice.cli.cosyvoice import CosyVoice
 from cosyvoice.utils.file_utils import load_wav
 import torchaudio
 
-cosyvoice = CosyVoice('speech_tts/CosyVoice-300M-SFT')
+cosyvoice = CosyVoice('./pretrained_models/CosyVoice-300M-SFT')
 # sft usage
 print(cosyvoice.list_avaliable_spks())
 output = cosyvoice.inference_sft('你好，我是通义生成式语音大模型，请问有什么可以帮您的吗？', '中文女')
 torchaudio.save('sft.wav', output['tts_speech'], 22050)
 
-cosyvoice = CosyVoice('speech_tts/CosyVoice-300M')
+cosyvoice = CosyVoice('./pretrained_models/CosyVoice-300M')
 # zero_shot usage
 prompt_speech_16k = load_wav('zero_shot_prompt.wav', 16000)
 output = cosyvoice.inference_zero_shot('收到好友从远方寄来的生日礼物，那份意外的惊喜与深深的祝福让我心中充满了甜蜜的快乐，笑容如花儿般绽放。', '希望你以后能够做的比我还好呦。', prompt_speech_16k)
@@ -94,7 +94,7 @@ prompt_speech_16k = load_wav('cross_lingual_prompt.wav', 16000)
 output = cosyvoice.inference_cross_lingual('<|en|>And then later on, fully acquiring that company. So keeping management in line, interest in line with the asset that\'s coming into the family is a reason why sometimes we don\'t buy the whole thing.', prompt_speech_16k)
 torchaudio.save('cross_lingual.wav', output['tts_speech'], 22050)
 
-cosyvoice = CosyVoice('speech_tts/CosyVoice-300M-Instruct')
+cosyvoice = CosyVoice('./pretrained_models/CosyVoice-300M-Instruct')
 # instruct usage
 output = cosyvoice.inference_instruct('在面对挑战时，他展现了非凡的<strong>勇气</strong>与<strong>智慧</strong>。', '中文男', 'Theo \'Crimson\', is a fiery, passionate rebel leader. Fights with fervor for justice, but struggles with impulsiveness.')
 torchaudio.save('instruct.wav', output['tts_speech'], 22050)
@@ -108,8 +108,8 @@ We support sft/zero_shot/cross_lingual/instruct inference in web demo.
 Please see the demo website for details.
 
 ``` python
-# change speech_tts/CosyVoice-300M-SFT for sft inference, or speech_tts/CosyVoice-300M-Instruct for instruct inference
-python3 webui.py --port 50000 --model_dir speech_tts/CosyVoice-300M
+# change ./pretrained_models/CosyVoice-300M-SFT for sft inference, or ./pretrained_models/CosyVoice-300M-Instruct for instruct inference
+python3 webui.py --port 50000 --model_dir ./pretrained_models/CosyVoice-300M
 ```
 
 **Advanced Usage**


### PR DESCRIPTION
If the pre-trained model has already been downloaded to the pretrained_models directory, then the model should be loaded from the local directory instead of being re-downloaded when loading the model. If the model is downloaded again in the user's cache directory, it will cause unnecessary hard disk space waste.