### PR TITLE
更换默认ttsfrd为WeTextProcessing，修复半角句号结尾或者文本中没有标点会导致合成失败：RuntimeError: torch.cat(): expected a non-empty list of T…

### DIFF
--- a/cosyvoice/cli/frontend.py
+++ b/cosyvoice/cli/frontend.py
@@ -23,7 +23,12 @@ import os
 import inflect
 from tn.chinese.normalizer import Normalizer as ZhNormalizer
 from tn.english.normalizer import Normalizer as EnNormalizer
-
+try:
+    import ttsfrd
+    use_ttsfrd = True
+except:
+    print("failed to import ttsfrd, please normalize input text manually")
+    use_ttsfrd = False
 from cosyvoice.utils.frontend_utils import contains_chinese, replace_blank, replace_corner_mark, remove_bracket, spell_out_number, split_paragraph
 
 
@@ -50,8 +55,17 @@ class CosyVoiceFrontEnd:
         self.instruct = instruct
         self.allowed_special = allowed_special
         self.inflect_parser = inflect.engine()
-        self.zh_tn_model = ZhNormalizer(remove_erhua=False,full_to_half=False)
-        self.en_tn_model = EnNormalizer()
+        self.use_ttsfrd = use_ttsfrd
+        if self.use_ttsfrd:
+            self.frd = ttsfrd.TtsFrontendEngine()
+            ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+            assert self.frd.initialize('{}/../../pretrained_models/CosyVoice-ttsfrd/resource'.format(ROOT_DIR)) is True, 'failed to initialize ttsfrd resource'
+            self.frd.set_lang_type('pinyin')
+            self.frd.enable_pinyin_mix(True)
+            self.frd.set_breakmodel_index(1)
+        else:
+            self.zh_tn_model = ZhNormalizer(remove_erhua=False,full_to_half=False)
+            self.en_tn_model = EnNormalizer()	
 
     def _extract_text_token(self, text):
         text_token = self.tokenizer.encode(text, allowed_special=self.allowed_special)
@@ -86,7 +100,10 @@ class CosyVoiceFrontEnd:
     def text_normalize(self, text, split=True):
         text = text.strip()
         if contains_chinese(text):
-            text = self.zh_tn_model.normalize(text)
+            if self.use_ttsfrd:
+                text = self.frd.get_frd_extra_info(text, 'input')
+            else:
+                text = self.zh_tn_model.normalize(text)	
             text = text.replace("\n", "")
             text = replace_blank(text)
             text = replace_corner_mark(text)

--- a/cosyvoice/cli/frontend.py
+++ b/cosyvoice/cli/frontend.py
@@ -21,12 +21,9 @@ import torchaudio.compliance.kaldi as kaldi
 import torchaudio
 import os
 import inflect
-try:
-    import ttsfrd
-    use_ttsfrd = True
-except:
-    print("failed to import ttsfrd, please normalize input text manually")
-    use_ttsfrd = False
+from tn.chinese.normalizer import Normalizer as ZhNormalizer
+from tn.english.normalizer import Normalizer as EnNormalizer
+
 from cosyvoice.utils.frontend_utils import contains_chinese, replace_blank, replace_corner_mark, remove_bracket, spell_out_number, split_paragraph
 
 
@@ -53,14 +50,8 @@ class CosyVoiceFrontEnd:
         self.instruct = instruct
         self.allowed_special = allowed_special
         self.inflect_parser = inflect.engine()
-        self.use_ttsfrd = use_ttsfrd
-        if self.use_ttsfrd:
-            self.frd = ttsfrd.TtsFrontendEngine()
-            ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
-            assert self.frd.initialize('{}/../../pretrained_models/CosyVoice-ttsfrd/resource'.format(ROOT_DIR)) is True, 'failed to initialize ttsfrd resource'
-            self.frd.set_lang_type('pinyin')
-            self.frd.enable_pinyin_mix(True)
-            self.frd.set_breakmodel_index(1)
+        self.zh_tn_model = ZhNormalizer(remove_erhua=False,full_to_half=False)
+        self.en_tn_model = EnNormalizer()
 
     def _extract_text_token(self, text):
         text_token = self.tokenizer.encode(text, allowed_special=self.allowed_special)
@@ -95,8 +86,7 @@ class CosyVoiceFrontEnd:
     def text_normalize(self, text, split=True):
         text = text.strip()
         if contains_chinese(text):
-            if self.use_ttsfrd:
-                text = self.frd.get_frd_extra_info(text, 'input')
+            text = self.zh_tn_model.normalize(text)
             text = text.replace("\n", "")
             text = replace_blank(text)
             text = replace_corner_mark(text)
@@ -107,6 +97,7 @@ class CosyVoiceFrontEnd:
                                                 token_min_n=60, merge_len=20,
                                                 comma_split=False)]
         else:
+            text = self.en_tn_model.normalize(text)
             text = spell_out_number(text, self.inflect_parser)
             texts = [i for i in split_paragraph(text, partial(self.tokenizer.encode, allowed_special=self.allowed_special), "en", token_max_n=80,
                                                 token_min_n=60, merge_len=20,

--- a/cosyvoice/utils/frontend_utils.py
+++ b/cosyvoice/utils/frontend_utils.py
@@ -91,6 +91,8 @@ def split_paragraph(text: str, tokenize, lang="zh", token_max_n=80, token_min_n=
                 st = i + 2
             else:
                 st = i + 1
+    if len(utts) == 0:
+        utts.append(text)
     final_utts = []
     cur_utt = ""
     for utt in utts:

--- a/cosyvoice/utils/frontend_utils.py
+++ b/cosyvoice/utils/frontend_utils.py
@@ -92,7 +92,10 @@ def split_paragraph(text: str, tokenize, lang="zh", token_max_n=80, token_min_n=
             else:
                 st = i + 1
     if len(utts) == 0:
-        utts.append(text)
+        if lang == "zh":
+            utts.append(text + '。')
+        else:
+            utts.append(text + '.')
     final_utts = []
     cur_utt = ""
     for utt in utts:

--- a/cosyvoice/utils/frontend_utils.py
+++ b/cosyvoice/utils/frontend_utils.py
@@ -74,7 +74,7 @@ def split_paragraph(text: str, tokenize, lang="zh", token_max_n=80, token_min_n=
             return len(tokenize(_text)) < merge_len
 
     if lang == "zh":
-        pounc = ['。', '？', '！', '；', '：', '.', '?', '!', ';']
+        pounc = ['。', '？', '！', '；', '：', '、', '.', '?', '!', ';']
     else:
         pounc = ['.', '?', '!', ';', ':']
     if comma_split:

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ tensorboard==2.14.0
 torch==2.0.1
 torchaudio==2.0.2
 wget==3.2
+WeTextProcessing


### PR DESCRIPTION
…ensors

text='小明因为感冒,鼻子不通,讲话总带着齉音.'
  File "/usr/local/data/CosyVoice/cosyvoice/cli/cosyvoice.py", line 62, in inference_zero_shot
    return {'tts_speech': torch.concat(tts_speeches, dim=1)}
RuntimeError: torch.cat(): expected a non-empty list of Tensors

原因为self.frontend.text_normalize(tts_text, split=True)返回为空