### PR TITLE
接口服务允许跨域请求，接入其他服务，比如ollama或者其他大模型服务

### DIFF
--- a/runtime/python/fastapi/server.py
+++ b/runtime/python/fastapi/server.py
@@ -10,6 +10,7 @@ import sys
 import io,time
 from fastapi import FastAPI, Response, File, UploadFile, Form
 from fastapi.responses import HTMLResponse
+from fastapi.middleware.cors import CORSMiddleware  #引入 CORS中间件模块
 from contextlib import asynccontextmanager
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 sys.path.append('{}/../../..'.format(ROOT_DIR))
@@ -38,6 +39,15 @@ async def lifespan(app: FastAPI):
     yield
 
 app = FastAPI(lifespan=lifespan)
+
+#设置允许访问的域名
+origins = ["*"]  #"*"，即为所有,也可以改为允许的特定ip。
+app.add_middleware(
+    CORSMiddleware, 
+    allow_origins=origins,  #设置允许的origins来源
+    allow_credentials=True,
+    allow_methods=["*"],  # 设置允许跨域的http方法，比如 get、post、put等。
+    allow_headers=["*"])  #允许跨域的headers，可以用来鉴别来源等作用。
 
 def buildResponse(output):
     buffer = io.BytesIO()


### PR DESCRIPTION
接口服务允许跨域请求，接入其他服务，比如ollama或者其他大模型服务

跨域资源共享 (CORS) 是一种机制，它允许在不同域中的客户端 Web 应用程序与其他域中的资源进行交互。  这在现代 Web 开发中非常有用，因为复杂的应用程序经常引用其客户端代码中的第三方 API 和资源。