### PR TITLE
[WIP] Kvcache fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,22 +87,26 @@ cosyvoice = CosyVoice('pretrained_models/CosyVoice-300M-SFT')
 # sft usage
 print(cosyvoice.list_avaliable_spks())
 output = cosyvoice.inference_sft('你好，我是通义生成式语音大模型，请问有什么可以帮您的吗？', '中文女')
-torchaudio.save('sft.wav', output['tts_speech'], 22050)
+for idx, itr in enumerate(output):
+    torchaudio.save(f"sft_{idx}.wav", itr['tts_speech'], 22050)
 
 cosyvoice = CosyVoice('pretrained_models/CosyVoice-300M')
 # zero_shot usage, <|zh|><|en|><|jp|><|yue|><|ko|> for Chinese/English/Japanese/Cantonese/Korean
 prompt_speech_16k = load_wav('zero_shot_prompt.wav', 16000)
 output = cosyvoice.inference_zero_shot('收到好友从远方寄来的生日礼物，那份意外的惊喜与深深的祝福让我心中充满了甜蜜的快乐，笑容如花儿般绽放。', '希望你以后能够做的比我还好呦。', prompt_speech_16k)
-torchaudio.save('zero_shot.wav', output['tts_speech'], 22050)
+for idx, itr in enumerate(output):
+    torchaudio.save(f"zero_shot_{idx}.wav", itr['tts_speech'], 22050)
 # cross_lingual usage
 prompt_speech_16k = load_wav('cross_lingual_prompt.wav', 16000)
 output = cosyvoice.inference_cross_lingual('<|en|>And then later on, fully acquiring that company. So keeping management in line, interest in line with the asset that\'s coming into the family is a reason why sometimes we don\'t buy the whole thing.', prompt_speech_16k)
-torchaudio.save('cross_lingual.wav', output['tts_speech'], 22050)
+for idx, itr in enumerate(output):
+    torchaudio.save(f"cross_lingual_{idx}.wav", itr['tts_speech'], 22050)
 
 cosyvoice = CosyVoice('pretrained_models/CosyVoice-300M-Instruct')
 # instruct usage, support <laughter></laughter><strong></strong>[laughter][breath]
 output = cosyvoice.inference_instruct('在面对挑战时，他展现了非凡的<strong>勇气</strong>与<strong>智慧</strong>。', '中文男', 'Theo \'Crimson\', is a fiery, passionate rebel leader. Fights with fervor for justice, but struggles with impulsiveness.')
-torchaudio.save('instruct.wav', output['tts_speech'], 22050)
+for idx, itr in enumerate(output):
+    torchaudio.save(f"instruct_{idx}.wav", itr['tts_speech'], 22050)
 ```
 
 **Start web demo**

--- a/cosyvoice/llm/llm.py
+++ b/cosyvoice/llm/llm.py
@@ -199,7 +199,7 @@ class TransformerLM(torch.nn.Module):
         cache_offset = 0
 
         for i in range(max_len):
-            y_pred, key_caches, value_caches, cnn_cache = self.llm.forward_chunk(
+            y_pred, att_cache, cnn_cache = self.llm.forward_chunk(
                                                                         lm_input, offset=0,
                                                                         required_cache_size=-1,
                                                                         att_cache=att_cache,

--- a/cosyvoice/transformer/encoder.py
+++ b/cosyvoice/transformer/encoder.py
@@ -187,8 +187,7 @@ class BaseEncoder(torch.nn.Module):
         xs: torch.Tensor,
         offset: int,
         required_cache_size: int,
-        key_caches: list,
-        value_caches: list,
+        att_cache: list,
         cache_offset: int,
         cnn_cache: torch.Tensor = torch.zeros(0, 0, 0, 0),
         att_mask: torch.Tensor = torch.ones((0, 0, 0), dtype=torch.bool),
@@ -204,11 +203,8 @@ class BaseEncoder(torch.nn.Module):
                 compuation
                 >=0: actual cache size
                 <0: means all history cache is required
-            att_cache (torch.Tensor): cache tensor for KEY & VALUE in
-                transformer/conformer attention, with shape
-                (elayers, head, cache_t1, d_k * 2), where
-                `head * d_k == hidden-dim` and
-                `cache_t1 == chunk_size * num_decoding_left_chunks`.
+            att_cache (list): cache tensor for KEY & VALUE in
+                transformer/conformer attention.
             cnn_cache (torch.Tensor): cache tensor for cnn_module in conformer,
                 (elayers, b=1, hidden-dim, cache_t2), where
                 `cache_t2 == cnn.lorder - 1`
@@ -246,33 +242,31 @@ class BaseEncoder(torch.nn.Module):
             next_cache_start = attention_key_size
         else:
             next_cache_start = max(attention_key_size - required_cache_size, 0)
-
+        r_att_cache = []
         r_cnn_cache = []
         for i, layer in enumerate(self.encoders):
             # NOTE(xcsong): Before layer.forward
-            #   shape(key_caches[i:i + 1]) is (1, head, cache_offset, d_k),
-            #   shape(value_caches[i:i + 1]) is (1, head, cache_offset, d_k),
+            #   att_cache[i]              is (k_cache, v_cache), where k_cache's and v_cache's shape is (batch, nheads, cache_offset, head_dim)
             #   shape(cnn_cache[i])       is (b=1, hidden-dim, cache_t2)
-            xs, _, key_caches[i], value_caches[i], new_cnn_cache = layer(
+            xs, _, new_att_cache, new_cnn_cache = layer(
                 xs,
                 att_mask,
                 pos_emb,
-                key_cache=key_caches[i],
-                value_cache=value_caches[i],
+                att_cache=att_cache[i],
                 cache_offset=cache_offset,
                 cnn_cache=cnn_cache[i] if cnn_cache.size(0) > 0 else cnn_cache)
             # NOTE(xcsong): After layer.forward
             #   shape(new_att_cache) is (batch, head, attention_key_size, d_k * 2),
             #   shape(new_cnn_cache) is (b=1, hidden-dim, cache_t2)
+            r_att_cache.append(new_att_cache)
             r_cnn_cache.append(new_cnn_cache.unsqueeze(0))
-
         if self.normalize_before:
             xs = self.after_norm(xs)
 
         # NOTE(xcsong): shape(r_cnn_cache) is (e, b=1, hidden-dim, cache_t2)
         r_cnn_cache = torch.cat(r_cnn_cache, dim=0)
 
-        return (xs, key_caches, value_caches, r_cnn_cache)
+        return (xs, r_att_cache, r_cnn_cache)
 
     # TODO: need to fix kv cache.
     def forward_chunk_by_chunk(

--- a/cosyvoice/transformer/encoder.py
+++ b/cosyvoice/transformer/encoder.py
@@ -168,7 +168,7 @@ class BaseEncoder(torch.nn.Module):
                        pos_emb: torch.Tensor,
                        mask_pad: torch.Tensor) -> torch.Tensor:
         for layer in self.encoders:
-            xs, chunk_masks, _, _, _ = layer(xs, chunk_masks, pos_emb, mask_pad)
+            xs, chunk_masks, _, _ = layer(xs, chunk_masks, pos_emb, mask_pad)
         return xs
 
     @torch.jit.ignore(drop=True)

--- a/cosyvoice/transformer/encoder_layer.py
+++ b/cosyvoice/transformer/encoder_layer.py
@@ -61,7 +61,9 @@ class TransformerEncoderLayer(nn.Module):
         mask: torch.Tensor,
         pos_emb: torch.Tensor,
         mask_pad: torch.Tensor = torch.ones((0, 0, 0), dtype=torch.bool),
-        att_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
+        key_cache: torch.Tensor = None,
+        value_cache: torch.Tensor = None,
+        cache_offset: int = 0,
         cnn_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Compute encoded features.
@@ -90,7 +92,7 @@ class TransformerEncoderLayer(nn.Module):
         residual = x
         if self.normalize_before:
             x = self.norm1(x)
-        x_att, new_att_cache = self.self_attn(x, x, x, mask, pos_emb=pos_emb, cache=att_cache)
+        x_att, key_cache, value_cache = self.self_attn(x, x, x, mask, pos_emb=pos_emb, key_cache=key_cache, value_cache=value_cache, cache_offset=cache_offset)
         x = residual + self.dropout(x_att)
         if not self.normalize_before:
             x = self.norm1(x)
@@ -103,7 +105,7 @@ class TransformerEncoderLayer(nn.Module):
             x = self.norm2(x)
 
         fake_cnn_cache = torch.zeros((0, 0, 0), dtype=x.dtype, device=x.device)
-        return x, mask, new_att_cache, fake_cnn_cache
+        return x, mask, key_cache, value_cache, fake_cnn_cache
 
 
 class ConformerEncoderLayer(nn.Module):
@@ -163,7 +165,9 @@ class ConformerEncoderLayer(nn.Module):
         mask: torch.Tensor,
         pos_emb: torch.Tensor,
         mask_pad: torch.Tensor = torch.ones((0, 0, 0), dtype=torch.bool),
-        att_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
+        key_cache: torch.Tensor = None,
+        value_cache: torch.Tensor = None,
+        cache_offset: int = 0,
         cnn_cache: torch.Tensor = torch.zeros((0, 0, 0, 0)),
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Compute encoded features.
@@ -202,8 +206,8 @@ class ConformerEncoderLayer(nn.Module):
         residual = x
         if self.normalize_before:
             x = self.norm_mha(x)
-        x_att, new_att_cache = self.self_attn(x, x, x, mask, pos_emb,
-                                              att_cache)
+        x_att, key_cache, value_cache = self.self_attn(x, x, x, mask, pos_emb,
+                                              key_cache, value_cache, cache_offset)
         x = residual + self.dropout(x_att)
         if not self.normalize_before:
             x = self.norm_mha(x)
@@ -233,4 +237,4 @@ class ConformerEncoderLayer(nn.Module):
         if self.conv_module is not None:
             x = self.norm_final(x)
 
-        return x, mask, new_att_cache, new_cnn_cache
+        return x, mask, key_cache, value_cache, new_cnn_cache


### PR DESCRIPTION
Remove all original concatenation handling of kv cache to avoid unnecessary processing of long length kv. Preallocate the required space for kv cache so that it is not necessary to reallocate kv cache each time a new step result is filled in.
