### PR TITLE
Fix: Docker 'CUFFT_INTERNAL_ERROR' issue

### DIFF
--- a/runtime/python/Dockerfile
+++ b/runtime/python/Dockerfile
@@ -10,4 +10,7 @@ RUN git lfs install
 RUN git clone --recursive https://github.com/FunAudioLLM/CosyVoice.git
 # here we use python==3.10 because we cannot find an image which have both python3.8 and torch2.0.1-cu118 installed
 RUN cd CosyVoice && pip3 install -r requirements.txt -i https://mirrors.aliyun.com/pypi/simple/ --trusted-host=mirrors.aliyun.com
+# To solve the CUFFT_INTERNAL_ERROR bug in cu11.7 pytorch, see https://forums.developer.nvidia.com/t/bug-ubuntu-on-wsl2-rtx4090-related-cufft-runtime-error/230883
+RUN pip uninstall torch torchaudio
+RUN pip install torch==2.0.1 torchaudio==2.0.2 --index-url https://download.pytorch.org/whl/cu118
 RUN cd CosyVoice/runtime/python/grpc && python3 -m grpc_tools.protoc -I. --python_out=. --grpc_python_out=. cosyvoice.proto


### PR DESCRIPTION
There comes an issue that cuFFT cannot work in the docker, as the version of pytorch is cu11.7 and there are some related discussions:

- https://forums.developer.nvidia.com/t/bug-ubuntu-on-wsl2-rtx4090-related-cufft-runtime-error/230883/5
- https://github.com/pytorch/pytorch/issues/88038

Uninstall the 11.7 version when building the docker can solve this.