### PR TITLE
fastapi服务启动限制ip从127.0.0.1改为0.0.0.0，这样docker映射端口才可以使用

### DIFF
--- a/runtime/python/fastapi/server.py
+++ b/runtime/python/fastapi/server.py
@@ -80,4 +80,4 @@ if __name__ == '__main__':
                         help='local path or modelscope repo id')
     args = parser.parse_args()
     cosyvoice = CosyVoice(args.model_dir)
-    uvicorn.run(app, host="127.0.0.1", port=args.port)
+    uvicorn.run(app, host="0.0.0.0", port=args.port)


### PR DESCRIPTION
fastapi服务启动限制ip从127.0.0.1改为0.0.0.0，这样docker映射端口才可以使用