### PR TITLE
fix nucleus_sampling

### DIFF
--- a/cosyvoice/utils/common.py
+++ b/cosyvoice/utils/common.py
@@ -120,7 +120,7 @@ def nucleus_sampling(weighted_scores, top_p=0.8, top_k=25):
     sorted_value, sorted_idx = weighted_scores.softmax(dim=0).sort(descending=True, stable=True)
     for i in range(len(sorted_idx)):
         # sampling both top-p and numbers.
-        if cum_prob < top_p and len(prob) < top_k:
+        if (cum_prob < top_p or len(prob) <= 1) and len(prob) < top_k:
             cum_prob += sorted_value[i]
             prob.append(sorted_value[i])
             indices.append(sorted_idx[i])


### PR DESCRIPTION
When the first value of `prob` is greater than 0.8 and its `ids` is `speech_token_size` (4096), it causes `prob.multinomial` to always select this value, ultimately resulting in an infinite loop (`cosyvoice/llm/llm.py` sampling_ids() method). 

**Fix:** Ensure that `prob` always has at least two values for `multinomial`.
