### PR TITLE
[debug] support flow cache, for sharper tts_mel output (handle prompt bug)

### DIFF
--- a/cosyvoice/flow/flow.py
+++ b/cosyvoice/flow/flow.py
@@ -109,7 +109,9 @@ class MaskedDiffWithXvec(torch.nn.Module):
                   prompt_token_len,
                   prompt_feat,
                   prompt_feat_len,
-                  embedding):
+                  embedding,
+                  required_cache_size=0,
+                  flow_cache=None):
         assert token.shape[0] == 1
         # xvec projection
         embedding = F.normalize(embedding, dim=1)
@@ -133,13 +135,15 @@ class MaskedDiffWithXvec(torch.nn.Module):
         conds = conds.transpose(1, 2)
 
         mask = (~make_pad_mask(torch.tensor([mel_len1 + mel_len2]))).to(h)
-        feat = self.decoder(
+        feat, flow_cache = self.decoder(
             mu=h.transpose(1, 2).contiguous(),
             mask=mask.unsqueeze(1),
             spks=embedding,
             cond=conds,
-            n_timesteps=10
+            n_timesteps=10,
+            required_cache_size=required_cache_size,
+            flow_cache=flow_cache
         )
         feat = feat[:, :, mel_len1:]
         assert feat.shape[2] == mel_len2
-        return feat
+        return feat, flow_cache

--- a/cosyvoice/flow/flow.py
+++ b/cosyvoice/flow/flow.py
@@ -141,6 +141,7 @@ class MaskedDiffWithXvec(torch.nn.Module):
             spks=embedding,
             cond=conds,
             n_timesteps=10,
+            prompt_len=mel_len1,
             required_cache_size=required_cache_size,
             flow_cache=flow_cache
         )

--- a/cosyvoice/flow/flow_matching.py
+++ b/cosyvoice/flow/flow_matching.py
@@ -32,7 +32,7 @@ class ConditionalCFM(BASECFM):
         self.estimator = estimator
 
     @torch.inference_mode()
-    def forward(self, mu, mask, n_timesteps, temperature=1.0, spks=None, cond=None):
+    def forward(self, mu, mask, n_timesteps, temperature=1.0, spks=None, cond=None, required_cache_size=0, flow_cache=None):
         """Forward diffusion
 
         Args:
@@ -50,11 +50,26 @@ class ConditionalCFM(BASECFM):
             sample: generated mel-spectrogram
                 shape: (batch_size, n_feats, mel_timesteps)
         """
-        z = torch.randn_like(mu) * temperature
+
+        if flow_cache is not None:
+            z_cache = flow_cache[0]
+            mu_cache = flow_cache[1]
+            z = torch.randn((mu.size(0), mu.size(1), mu.size(2) - z_cache.size(2)), dtype=mu.dtype, device=mu.device) * temperature
+            z = torch.cat((z_cache, z), dim=2) # [B, 80, T]
+            mu = torch.cat((mu_cache, mu[..., mu_cache.size(2):]), dim=2) # [B, 80, T]
+        else:
+            z = torch.randn_like(mu) * temperature
+
+        next_cache_start = max(z.size(2) - required_cache_size, 0)
+        flow_cache = [
+            z[..., next_cache_start:],
+            mu[..., next_cache_start:]
+        ]
+
         t_span = torch.linspace(0, 1, n_timesteps + 1, device=mu.device, dtype=mu.dtype)
         if self.t_scheduler == 'cosine':
             t_span = 1 - torch.cos(t_span * 0.5 * torch.pi)
-        return self.solve_euler(z, t_span=t_span, mu=mu, mask=mask, spks=spks, cond=cond)
+        return self.solve_euler(z, t_span=t_span, mu=mu, mask=mask, spks=spks, cond=cond), flow_cache
 
     def solve_euler(self, x, t_span, mu, mask, spks, cond):
         """

--- a/cosyvoice/flow/flow_matching.py
+++ b/cosyvoice/flow/flow_matching.py
@@ -32,7 +32,7 @@ class ConditionalCFM(BASECFM):
         self.estimator = estimator
 
     @torch.inference_mode()
-    def forward(self, mu, mask, n_timesteps, temperature=1.0, spks=None, cond=None, required_cache_size=0, flow_cache=None):
+    def forward(self, mu, mask, n_timesteps, temperature=1.0, spks=None, cond=None, prompt_len=0, required_cache_size=0, flow_cache=None):
         """Forward diffusion
 
         Args:
@@ -62,8 +62,8 @@ class ConditionalCFM(BASECFM):
 
         next_cache_start = max(z.size(2) - required_cache_size, 0)
         flow_cache = [
-            z[..., next_cache_start:],
-            mu[..., next_cache_start:]
+            torch.cat((z[..., :prompt_len], z[..., next_cache_start:]), dim=2),
+            torch.cat((mu[..., :prompt_len], mu[..., next_cache_start:]), dim=2)
         ]
 
         t_span = torch.linspace(0, 1, n_timesteps + 1, device=mu.device, dtype=mu.dtype)


### PR DESCRIPTION
#379 问题2的解决方案

flowmatching中的z和mu，跨chunk时对于每个index不是定值，是导致衔接处频谱模糊的因素之一（本质是flow的attention context问题，无解。需要重训模型+context cache，非常复杂）

有益效果：
1、可以改善衔接处频谱模糊、发音不清晰问题
2、可以改善衔接处断音问题
3、可以改善音量突变或音量异常问题

图中是flow的tts_mel输出，用于对比上下文及频谱模糊的问题
大图1列：不带cache；2列：带cache
小图左：前chunk最后34；中：（前+后）/2；右：后chunk开头34
可以发现带cache的，tts_mel频谱更清晰
需要注意的是，对于zeroshot，由于带了prompt输入，所以这部分的cache也需要额外考虑
<img width="787" alt="c6695df4a89fd9984754a37bba6644f" src="https://github.com/user-attachments/assets/2a56aa81-476c-40b7-88cb-b4f1d276cd7e">

备注：
1、由于后续的mel fade、hifigan cache、speech fade的挽救，该项虽然更本质，但最终听感提升概率较小
2、对于默认配置，断音出现周期为2s，若此时刻恰好没有发音，就难以发现区别，因此不保证每条case必然出现至少一处改善
3、flow matching 的输入Z和MU使用cache结果是有意义的。首先可以减少随机性、提升结果稳定性；其次未来做causal同样需要使用此cache，是可以复用的

已测有效的用例：
SFT
`cosyvoice = CosyVoice('pretrained_models/CosyVoice-300M-SFT')
cosyvoice.inference_sft('收到好友从远方寄来的生日礼物，那份意外的惊喜与深深的祝福让我心中充满了甜蜜的快乐，笑容如花儿般绽放。', '中文女', stream=True)`

zeroshot
`
cosyvoice = CosyVoice('pretrained_models/CosyVoice-300M-25Hz')
prompt_speech_16k = load_wav('zero_shot_prompt.wav', 16000)
cosyvoice.inference_zero_shot('收到好友从远方寄来的生日礼物，那份意外的惊喜与深深的祝福让我心中充满了甜蜜的快乐，笑容如花儿般绽放。', '希望你以后能够做的比我还好呦。', prompt_speech_16k, stream=True)
`
zeroshot 改进前
![image](https://github.com/user-attachments/assets/4b680f49-3d0e-41de-9c76-d3585b0f9d86)
zeroshot 改进后
![image](https://github.com/user-attachments/assets/b695bd87-5d1e-4b7d-b696-5b6c53d79f95)


