### PR TITLE
release flow_cache_dict to prevent potential memory leaks in long-running processes

### DIFF
--- a/cosyvoice/cli/model.py
+++ b/cosyvoice/cli/model.py
@@ -201,6 +201,7 @@ class CosyVoiceModel:
             self.llm_end_dict.pop(this_uuid)
             self.mel_overlap_dict.pop(this_uuid)
             self.hift_cache_dict.pop(this_uuid)
+            self.flow_cache_dict.pop(this_uuid)
 
     def vc(self, source_speech_token, flow_prompt_speech_token, prompt_speech_feat, flow_embedding, stream=False, speed=1.0, **kwargs):
         # this_uuid is used to track variables related to this inference thread


### PR DESCRIPTION
#### Commit Message:

"Release flow_cache_dict resources to prevent memory leak"

### Description:

This commit addresses a potential memory leak by releasing resources held by flow_cache_dict, which temporarily stores cached data associated with specific this_uuid identifiers. Without releasing or clearing outdated this_uuid entries, the dictionary could accumulate unused references.