### PR TITLE
fix the bug of constantlr and deespeed

### DIFF
--- a/cosyvoice/utils/train_utils.py
+++ b/cosyvoice/utils/train_utils.py
@@ -132,11 +132,14 @@ def init_optimizer_and_scheduler(args, configs, model, gan):
         # use deepspeed optimizer for speedup
         if args.train_engine == "deepspeed":
             def scheduler(opt):
-                return scheduler_type(opt, **configs['train_conf']['scheduler_conf'])
+                if configs['train_conf']['scheduler'] == 'constantlr':
+                    return scheduler_type(opt)
+                else:
+                    return scheduler_type(opt, **configs['train_conf']['scheduler_conf'])
             model, optimizer, _, scheduler = deepspeed.initialize(
                 args=args,
                 model=model,
-                optimizer=None,
+                optimizer=optimizer,
                 lr_scheduler=scheduler,
                 model_parameters=model.parameters())
 


### PR DESCRIPTION
修复使用deepspeed训练，且scheduler为constantlr时的bug：
1. 原有代码传入的是conf/ds_stage2.json中的optimizer，并未传入yaml文件中的optimizer。
2. constantlr会报关于scheduler_conf和warmup_steps的KeyError

在yaml中设置lr为0.00001，
修复bug之前的log：
`TypeError: __init__() got an unexpected keyword argument 'warmup_steps'`
`2024-12-19 11:25:00,526 DEBUG TRAIN Batch 0/100 loss 3.138866 acc 0.303122 lr 0.00100000 grad_norm 0.286094 rank 0`
修复bug之后的log：
`2024-12-19 06:20:32,664 DEBUG TRAIN Batch 0/100 loss 3.581383 acc 0.204409 lr 0.00001000 grad_norm 1.757465 rank 0`
