### PR TITLE
repair infinity running bug in cosyvoice/llm/llm.py/sampling_ids()

### DIFF
--- a/cosyvoice/llm/llm.py
+++ b/cosyvoice/llm/llm.py
@@ -279,10 +279,13 @@ class Qwen2LM(torch.nn.Module):
             decoded_tokens: List,
             sampling: int,
             ignore_eos: bool = True,
+            max_sample_count:int = 10,
     ):
+        count = 0
         while True:
+            count += 1
             top_ids = self.sampling(weighted_scores, decoded_tokens, sampling)
-            if (not ignore_eos) or (self.speech_token_size not in top_ids):
+            if (not ignore_eos) or (self.speech_token_size not in top_ids) or (count > max_sample_count):
                 break
         return top_ids
 


### PR DESCRIPTION
this a fatal bug, please pay attention to it.

while call "sampling_ids" function with "ignore_eos=True"(default vlaue), the "top_ids" will always be [6561] sometimes, which equal to "self.speech_token_size", and cause the while loop will not be break forever.

Here is an example of triggering this bug using inference_zero_shot function:

tts_text : "用严肃的粤语回答我的问题。你如何在风景画中创造深度？"
prompt_text : "你如何在风景画中创造深度？"
prompt_audio : "loop.wav"

the link of prompt_audio :
链接:https://pan.baidu.com/s/1VerfOaI8uQqx2MjfKXyGSw?pwd=xatv 提取码: xatv