### PR TITLE
fix the bug of constantlr while using the deepspeed engine

### DIFF
--- a/cosyvoice/utils/train_utils.py
+++ b/cosyvoice/utils/train_utils.py
@@ -132,7 +132,10 @@ def init_optimizer_and_scheduler(args, configs, model, gan):
         # use deepspeed optimizer for speedup
         if args.train_engine == "deepspeed":
             def scheduler(opt):
-                return scheduler_type(opt, **configs['train_conf']['scheduler_conf'])
+                if configs['train_conf']['scheduler'] == 'constantlr':
+                    return scheduler_type(opt)
+                else:
+                    return scheduler_type(opt, **configs['train_conf']['scheduler_conf'])
             model, optimizer, _, scheduler = deepspeed.initialize(
                 args=args,
                 model=model,


### PR DESCRIPTION
使用DeepSpeed训练且设置constantlr时，会出现关于scheduler_conf的错误：
`TypeError: __init__() got an unexpected keyword argument 'warmup_steps'`
修复之后：
`2024-12-19 06:20:32,664 DEBUG TRAIN Batch 0/100 loss 3.581383 acc 0.204409 lr 0.00001000 grad_norm 1.757465 rank 0`