### PR TITLE
Fix diffusers / huggingface_hub compatibility in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,11 @@
 --extra-index-url https://aiinfra.pkgs.visualstudio.com/PublicPackages/_packaging/onnxruntime-cuda-12/pypi/simple/ # https://github.com/microsoft/onnxruntime/issues/21684
 conformer==0.3.2
 deepspeed==0.14.2; sys_platform == 'linux'
-diffusers==0.27.2
+diffusers==0.29.0
 gdown==5.1.0
 gradio==5.4.0
 grpcio==1.57.0
 grpcio-tools==1.57.0
-huggingface-hub==0.25.2
 hydra-core==1.3.2
 HyperPyYAML==1.2.2
 inflect==7.3.1


### PR DESCRIPTION
As mentioned in https://github.com/FunAudioLLM/CosyVoice/issues/516#issuecomment-2592067949 and https://github.com/FunAudioLLM/CosyVoice/issues/527#issuecomment-2592067100, it is more future-proof to upgrade `diffusers` version rather than downgrading `huggingface_hub` to an old one. This will also fix the `cannot import name 'cached_download' from 'huggingface_hub'` issue without relying on outdated packages.

Sorry again for the inconvenience :pray: