### PR TITLE
fix(pynini cython): Allow pynini to be built

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,4 @@ uvicorn==0.30.0
 wget==3.2
 fastapi==0.115.6
 fastapi-cli==0.0.4
-WeTextProcessing==1.0.3
+WeTextProcessing==1.0.4.1


### PR DESCRIPTION
Right now, Pynini fails with the error "Cython cannot be found". More information is available in the following issue:

  * https://github.com/kylebgorman/pynini/issues/30

This in turn, is used in the WeTextProcessing processing library. That library had a version bump, with the most recent version using an updated pynini library.

This commit uses that version. It is not clear whether ther are any other API breaking changes; the diff between v2.1.5 and 2.1.6 in pynini is big, but looks to be mostly docs and similar.