### PR TITLE
feat: add POST endpoints to resolve browser error about GET request wi…

### DIFF
--- a/runtime/python/fastapi/server.py
+++ b/runtime/python/fastapi/server.py
@@ -44,12 +44,14 @@ def generate_data(model_output):
 
 
 @app.get("/inference_sft")
+@app.post("/inference_sft")
 async def inference_sft(tts_text: str = Form(), spk_id: str = Form()):
     model_output = cosyvoice.inference_sft(tts_text, spk_id)
     return StreamingResponse(generate_data(model_output))
 
 
 @app.get("/inference_zero_shot")
+@app.post("/inference_zero_shot")
 async def inference_zero_shot(tts_text: str = Form(), prompt_text: str = Form(), prompt_wav: UploadFile = File()):
     prompt_speech_16k = load_wav(prompt_wav.file, 16000)
     model_output = cosyvoice.inference_zero_shot(tts_text, prompt_text, prompt_speech_16k)
@@ -57,6 +59,7 @@ async def inference_zero_shot(tts_text: str = Form(), prompt_text: str = Form(),
 
 
 @app.get("/inference_cross_lingual")
+@app.post("/inference_cross_lingual")
 async def inference_cross_lingual(tts_text: str = Form(), prompt_wav: UploadFile = File()):
     prompt_speech_16k = load_wav(prompt_wav.file, 16000)
     model_output = cosyvoice.inference_cross_lingual(tts_text, prompt_speech_16k)
@@ -64,6 +67,7 @@ async def inference_cross_lingual(tts_text: str = Form(), prompt_wav: UploadFile
 
 
 @app.get("/inference_instruct")
+@app.post("/inference_instruct")
 async def inference_instruct(tts_text: str = Form(), spk_id: str = Form(), instruct_text: str = Form()):
     model_output = cosyvoice.inference_instruct(tts_text, spk_id, instruct_text)
     return StreamingResponse(generate_data(model_output))


### PR DESCRIPTION
Title: Add POST endpoints for browser compatibility with file uploads

Description:
This PR adds POST endpoints for routes that handle file uploads, while maintaining the existing GET endpoints for compatibility. The change is necessary because:

1. Browser Limitations:
- Browsers strictly enforce HTTP specifications which prohibit GET requests from having a request body
- When uploading files through FormData, browsers will throw the error: "Failed to execute 'fetch' on 'Window': Request with GET/HEAD method cannot have body"

2. Technical Context:
- File uploads and form data must be sent in the request body
- While the backend can handle file data in GET requests, browsers cannot send such requests
- Adding POST endpoints allows browsers to properly upload files while maintaining backward compatibility

3. Changes Made:
- Added POST endpoints for routes handling file uploads 
- Maintained existing GET endpoints for API compatibility
- No changes to the underlying business logic


This modification ensures proper browser support while maintaining API compatibility.