### PR TITLE
CUDA with additional MPS and XPU support

### DIFF
--- a/cosyvoice/bin/inference.py
+++ b/cosyvoice/bin/inference.py
@@ -58,7 +58,15 @@ def main():
 
     # Init cosyvoice models from configs
     use_cuda = args.gpu >= 0 and torch.cuda.is_available()
-    device = torch.device('cuda' if use_cuda else 'cpu')
+    if torch.cuda.is_available():
+        device = torch.device('cuda:{}'.format(self.rank))
+    elif torch.backends.mps.is_available():
+        device = torch.device('mps')
+    elif torch.xpu.is_available():
+        device = torch.device('xpu')
+    else:
+        torch.device("cpu")
+        
     with open(args.config, 'r') as f:
         configs = load_hyperpyyaml(f)
 

--- a/cosyvoice/cli/frontend.py
+++ b/cosyvoice/cli/frontend.py
@@ -47,7 +47,6 @@ class CosyVoiceFrontEnd:
                  allowed_special: str = 'all'):
         self.tokenizer = get_tokenizer()
         self.feat_extractor = feat_extractor
-        self.device = torch.device('cpu')
 
         if torch.cuda.is_available():
             self.device = torch.device('cuda')
@@ -55,6 +54,8 @@ class CosyVoiceFrontEnd:
             self.device = torch.device('mps')
         elif torch.xpu.is_available():
             self.device = torch.device('xpu')
+        else:
+            self.device = torch.device('cpu')
             
         option = onnxruntime.SessionOptions()
         option.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL

--- a/cosyvoice/cli/frontend.py
+++ b/cosyvoice/cli/frontend.py
@@ -47,7 +47,15 @@ class CosyVoiceFrontEnd:
                  allowed_special: str = 'all'):
         self.tokenizer = get_tokenizer()
         self.feat_extractor = feat_extractor
-        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        self.device = torch.device('cpu')
+
+        if torch.cuda.is_available():
+            self.device = torch.device('cuda')
+        elif torch.backends.mps.is_available():
+            self.device = torch.device('mps')
+        elif torch.xpu.is_available():
+            self.device = torch.device('xpu')
+            
         option = onnxruntime.SessionOptions()
         option.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
         option.intra_op_num_threads = 1

--- a/cosyvoice/cli/model.py
+++ b/cosyvoice/cli/model.py
@@ -38,6 +38,8 @@ class CosyVoiceModel:
             self.device = torch.device('mps')
         elif torch.xpu.is_available():
             self.device = torch.device('xpu')
+        else:
+            self.device = torch.device('cpu')
             
         self.llm = llm
         self.flow = flow
@@ -312,6 +314,8 @@ class CosyVoice2Model(CosyVoiceModel):
             self.device = torch.device('mps')
         elif torch.xpu.is_available():
             self.device = torch.device('xpu')
+        else:
+            self.device = torch.device('cpu')
 
         self.llm = llm
         self.flow = flow

--- a/cosyvoice/utils/executor.py
+++ b/cosyvoice/utils/executor.py
@@ -30,7 +30,7 @@ class Executor:
         self.step = 0
         self.epoch = 0
         self.rank = int(os.environ.get('RANK', 0))
-        self.device = "cpu"
+        self.device = torch.device("cpu")
         if torch.cuda.is_available():
             self.device = torch.device('cuda:{}'.format(self.rank))
         elif torch.backends.mps.is_available():

--- a/cosyvoice/utils/executor.py
+++ b/cosyvoice/utils/executor.py
@@ -30,7 +30,13 @@ class Executor:
         self.step = 0
         self.epoch = 0
         self.rank = int(os.environ.get('RANK', 0))
-        self.device = torch.device('cuda:{}'.format(self.rank))
+        self.device = "cpu"
+        if torch.cuda.is_available():
+            self.device = torch.device('cuda:{}'.format(self.rank))
+        elif torch.backends.mps.is_available():
+            self.device = torch.device('mps')
+        elif torch.xpu.is_available():
+            self.device = torch.device('xpu')
 
     def train_one_epoc(self, model, optimizer, scheduler, train_data_loader, cv_data_loader, writer, info_dict, scaler, group_join):
         ''' Train one epoch


### PR DESCRIPTION
It is a few simple lines that allow MPS and XPU to pass through gatekeeping, enabling GPU other than NVIDIA's to run.

Caches, device setting, and GPU `assert` statements have been changed, though possible I overlooked something.

Note: I am unsure of the lines in `cosyvoice/cli/model.py` and whether they need to be changed, this one because I am not familiar with tensorRT:
`self.flow.decoder.estimator_engine = trt.Runtime(trt.Logger(trt.Logger.INFO)).deserialize_cuda_engine(f.read())`

And this will assign `nullcontext()`, but I see no alternative:
67/336
`self.llm_context = torch.cuda.stream(torch.cuda.Stream(self.device)) if torch.cuda.is_available() else nullcontext()`


