### PR TITLE
Fix: The use_flow_cache parameter is ignored, causing inference errors

### DIFF
--- a/cosyvoice/bin/inference.py
+++ b/cosyvoice/bin/inference.py
@@ -63,7 +63,7 @@ def main():
     try:
         with open(args.config, 'r') as f:
             configs = load_hyperpyyaml(f, overrides={'qwen_pretrain_path': args.qwen_pretrain_path})
-        model = CosyVoice2Model(configs['llm'], configs['flow'], configs['hift'], fp16=False)
+        model = CosyVoice2Model(configs['llm'], configs['flow'], configs['hift'], fp16=False, use_flow_cache=configs.get('use_flow_cache', False))
     except Exception:
         try:
             with open(args.config, 'r') as f:

--- a/examples/libritts/cosyvoice2/conf/cosyvoice2.yaml
+++ b/examples/libritts/cosyvoice2/conf/cosyvoice2.yaml
@@ -16,7 +16,7 @@ token_mel_ratio: 2
 # stream related params
 chunk_size: 25 # streaming inference chunk size, in token
 num_decoding_left_chunks: 1 # streaming inference flow decoder left chunk size, <0 means use all left chunks
-
+use_flow_cache: false  # or true, use to accelerate inference
 # model params
 # for all class/function included in this repo, we use !<name> or !<new> for intialization, so that user may find all corresponding class/function according to one single yaml.
 # for system/third_party class/function, we do not require this.


### PR DESCRIPTION
- Add use_flow_cache as a configurable parameter in config.yaml
- Update inference.py to pass use_flow_cache to CosyVoice2Model