### PR TITLE
在语音合成和自然语言控制中重新使用保存的3秒急速复刻音色。expand to reuse the saved zero_shot_spk_id in sft, instruct2

### DIFF
--- a/cosyvoice/cli/cosyvoice.py
+++ b/cosyvoice/cli/cosyvoice.py
@@ -72,6 +72,7 @@ class CosyVoice:
         model_input = self.frontend.frontend_zero_shot('', prompt_text, prompt_speech_16k, self.sample_rate, '')
         del model_input['text']
         del model_input['text_len']
+        model_input['embedding'] = model_input['llm_embedding']
         self.frontend.spk2info[zero_shot_spk_id] = model_input
         return True
 

--- a/cosyvoice/cli/frontend.py
+++ b/cosyvoice/cli/frontend.py
@@ -198,8 +198,15 @@ class CosyVoiceFrontEnd:
 
     def frontend_instruct2(self, tts_text, instruct_text, prompt_speech_16k, resample_rate, zero_shot_spk_id):
         model_input = self.frontend_zero_shot(tts_text, instruct_text + '<|endofprompt|>', prompt_speech_16k, resample_rate, zero_shot_spk_id)
-        del model_input['llm_prompt_speech_token']
-        del model_input['llm_prompt_speech_token_len']
+        if bool(zero_shot_spk_id):
+            prompt_text_token, prompt_text_token_len = self._extract_text_token(instruct_text + '<|endofprompt|>')
+            model_input['prompt_text'] = prompt_text_token
+            model_input['prompt_text_len'] = prompt_text_token_len
+        if 'llm_prompt_speech_token' in model_input.keys():
+            del model_input['llm_prompt_speech_token']
+        if 'llm_prompt_speech_token_len' in model_input.keys():
+            del model_input['llm_prompt_speech_token_len']
+
         return model_input
 
     def frontend_vc(self, source_speech_16k, prompt_speech_16k, resample_rate):


### PR DESCRIPTION
cosyvoice2.inference_instruct2中接收zero_shot_spk_id参数，但和add_zero_shot_spk生成并保存的zero_shot_spk_id内容有所不同。补丁中增加了缺失的部分，可以使用该参数正确执行。
同理，在inference_sft中也存在该情况。可以参考ReadMe.md中的例子，增加zero_shot_spk_id非空的情况复现。