### PR TITLE
[Bugfix] fix text generator as input

### DIFF
--- a/cosyvoice/cli/frontend.py
+++ b/cosyvoice/cli/frontend.py
@@ -121,7 +121,7 @@ class CosyVoiceFrontEnd:
     def text_normalize(self, text, split=True, text_frontend=True):
         if isinstance(text, Generator):
             logging.info('get tts_text generator, will skip text_normalize!')
-            return [text]
+            return text
         if text_frontend is False or text == '':
             return [text] if split is True else text
         text = text.strip()


### PR DESCRIPTION
When the input is a text generator like 
```python
to_generate = [
    "收到好友从远方寄来的生日礼物",
    "那份意外的惊喜与深深的祝福",
    "让我心中充满了甜蜜的快乐",
    "笑容如花儿般绽放。",
]
def text_generator():
    for i in to_generate:
        yield i

for i, j in enumerate(cosyvoice.inference_instruct2(text_generator(), "用温柔的语音说", prompt_speech_16k, stream=False)):
    torchaudio.save('instruct_{}.wav'.format(i), j['tts_speech'], cosyvoice.sample_rate)
```
the text normalizer behavior is wrong.