### PR TITLE
docs: fix Japanese language tag in example.py comment

### DIFF
--- a/example.py
+++ b/example.py
@@ -18,7 +18,7 @@ def cosyvoice_example():
     # zero_shot usage
     for i, j in enumerate(cosyvoice.inference_zero_shot('收到好友从远方寄来的生日礼物，那份意外的惊喜与深深的祝福让我心中充满了甜蜜的快乐，笑容如花儿般绽放。', '希望你以后能够做的比我还好呦。', './asset/zero_shot_prompt.wav')):
         torchaudio.save('zero_shot_{}.wav'.format(i), j['tts_speech'], cosyvoice.sample_rate)
-    # cross_lingual usage, <|zh|><|en|><|jp|><|yue|><|ko|> for Chinese/English/Japanese/Cantonese/Korean
+    # cross_lingual usage, <|zh|><|en|><|ja|><|yue|><|ko|> for Chinese/English/Japanese/Cantonese/Korean
     for i, j in enumerate(cosyvoice.inference_cross_lingual('<|en|>And then later on, fully acquiring that company. So keeping management in line, interest in line with the asset that\'s coming into the family is a reason why sometimes we don\'t buy the whole thing.',
                                                             './asset/cross_lingual_prompt.wav')):
         torchaudio.save('cross_lingual_{}.wav'.format(i), j['tts_speech'], cosyvoice.sample_rate)


### PR DESCRIPTION
## Summary
- Fixed incorrect Japanese language tag in `example.py` comment
- Changed `<|jp|>` to `<|ja|>` to match the actual tokenizer implementation

## Details
The comment at line 21 in `example.py` incorrectly documents the Japanese language tag as `<|jp|>`, but the actual `LANGUAGES` dict in `cosyvoice/tokenizer/tokenizer.py` defines it as `"ja": "japanese"` (line 19).

This mismatch can cause confusion and issues like #621 when users follow the documented tag.

## Test Plan
- [x] Verified `LANGUAGES` dict in tokenizer.py uses `ja` for Japanese
- [x] No code changes, only comment fix

Fixes #1683