### PR TITLE
fix(export): fix CosyVoice2 export and add CosyVoice3 support

### DIFF
--- a/cosyvoice/bin/export_jit.py
+++ b/cosyvoice/bin/export_jit.py
@@ -69,24 +69,12 @@ def main():
         script = get_optimized_script(flow_encoder.half())
         script.save('{}/flow.encoder.fp16.zip'.format(args.model_dir))
         logging.info('successfully export flow_encoder')
-    elif get_model_type(model.model) == CosyVoice2Model:
-        # 1. export llm text_encoder
-        llm_text_encoder = model.model.llm.text_encoder
-        script = get_optimized_script(llm_text_encoder)
-        script.save('{}/llm.text_encoder.fp32.zip'.format(args.model_dir))
-        script = get_optimized_script(llm_text_encoder.half())
-        script.save('{}/llm.text_encoder.fp16.zip'.format(args.model_dir))
-        logging.info('successfully export llm_text_encoder')
+    elif get_model_type(model.model) in [CosyVoice2Model, CosyVoice3Model]:
+        # Note: CosyVoice2/3 use Qwen2LM which doesn't have text_encoder attribute
+        # Text encoding is done via llm.llm.model.model.embed_tokens()
+        # See CosyVoice2Model.load_jit() which only loads flow_encoder
 
-        # 2. export llm llm
-        llm_llm = model.model.llm.llm
-        script = get_optimized_script(llm_llm, ['forward_chunk'])
-        script.save('{}/llm.llm.fp32.zip'.format(args.model_dir))
-        script = get_optimized_script(llm_llm.half(), ['forward_chunk'])
-        script.save('{}/llm.llm.fp16.zip'.format(args.model_dir))
-        logging.info('successfully export llm_llm')
-
-        # 3. export flow encoder
+        # 1. export flow encoder
         flow_encoder = model.model.flow.encoder
         script = get_optimized_script(flow_encoder)
         script.save('{}/flow.encoder.fp32.zip'.format(args.model_dir))


### PR DESCRIPTION
## Summary
- Fixed CosyVoice2 JIT export error (`AttributeError: 'Qwen2LM' object has no attribute 'text_encoder'`)
- Added CosyVoice3Model support to export_jit.py

## Problem
The `export_jit.py` script was incorrectly trying to export `llm.text_encoder` for CosyVoice2 models, but:
1. `Qwen2LM` class doesn't inherit `text_encoder` from `TransformerLM` (it calls `torch.nn.Module.__init__` directly)
2. `Qwen2LM` uses `llm.llm.model.model.embed_tokens()` for text embedding instead
3. `CosyVoice2Model.load_jit()` only loads `flow_encoder`, not `llm_text_encoder`

## Solution
- Removed the incorrect `text_encoder` export logic for CosyVoice2/3 models
- Only export `flow.encoder` which is what `CosyVoice2Model.load_jit()` actually uses
- Added `CosyVoice3Model` to the supported model types

## Test Plan
- [x] Code review of model architecture confirms fix is correct
- [x] `CosyVoice2Model.load_jit()` only requires `flow_encoder_model` parameter
- [x] `Qwen2LM` uses `embed_tokens()` not `text_encoder`

Fixes #1695
Fixes #1691