### PR TITLE
feat: implement instruct training in CosyVoice3 LLM forward pass

### DIFF
--- a/cosyvoice/llm/llm.py
+++ b/cosyvoice/llm/llm.py
@@ -675,9 +675,14 @@ class CosyVoice3LM(Qwen2LM):
         text_token_len = batch['text_token_len'].to(device)
         speech_token = batch['speech_token'].to(device)
         speech_token_len = batch['speech_token_len'].to(device)
-        # NOTE should append instruct_token to sequence, not implemented yet
         instruct_token = batch['instruct_token'].to(device)
         instruct_token_len = batch['instruct_token_len'].to(device)
+
+        # concat instruct_token to text_token, similar to inference
+        # if instruct_token exists (len > 0), prepend it to text_token
+        if instruct_token_len.sum() > 0:
+            text_token = torch.concat([instruct_token, text_token], dim=1)
+            text_token_len = text_token_len + instruct_token_len
 
         # 1. encode text_token
         text_token_emb = self.llm.model.model.embed_tokens(text_token)


### PR DESCRIPTION
    feat: implement instruct training in CosyVoice3 LLM forward pass
    
    - Concatenate instruct_token to text_token during training, similar to inference
    - Prepend instruct_token before text_token when instruct data exists
    - Update text_token_len accordingly to match concatenated sequence
    - Remove "not implemented yet" comment as feature is now complete
    
    This change enables the model to learn from instruct prompts (e.g.,
    "请用广东话表达") during training, making training and inference behavior
    consistent for instruct-based voice control.