### PR TITLE
fix: avoid variable shadowing of timestep `t` in compute_loss

### DIFF
--- a/cosyvoice/flow/flow_matching.py
+++ b/cosyvoice/flow/flow_matching.py
@@ -170,7 +170,7 @@ class ConditionalCFM(BASECFM):
             y: conditional flow
                 shape: (batch_size, n_feats, mel_timesteps)
         """
-        b, _, t = mu.shape
+        b, _, _ = mu.shape
 
         # random timestep
         t = torch.rand([b, 1, 1], device=mu.device, dtype=mu.dtype)


### PR DESCRIPTION
## Summary

In `cosyvoice/flow/flow_matching.py`, the `compute_loss()` method has a variable shadowing issue where `t` (the sequence length integer from shape unpacking) is immediately overwritten by `t` (the random timestep tensor):

```python
b, _, t = mu.shape          # t = sequence length (integer)
t = torch.rand([b, 1, 1], ...)  # t = random timestep (tensor) — immediately overwrites the above
```

The integer `t` from the shape unpacking is never used before being reassigned. While this doesn't cause a runtime error in the current code, it is misleading and fragile — a future developer might assume `t` still holds the sequence length after the unpacking line, leading to subtle bugs.

## Fix

Replace `b, _, t = mu.shape` with `b, _, _ = mu.shape` to make it explicit that only the batch dimension `b` is needed from the shape, and that the subsequent `t` is solely the random timestep tensor.

## Test plan

- [x] Verified that `t` (sequence length) is not referenced anywhere between the unpacking and the reassignment
- [x] Confirmed the change is semantically equivalent — no behavioral change, only improved clarity