### PR TITLE
Update cosyvoice2.py for vLLM

### DIFF
--- a/cosyvoice/utils/file_utils.py
+++ b/cosyvoice/utils/file_utils.py
@@ -46,7 +46,11 @@ def load_wav(wav, target_sr, min_sr=16000):
     # Use soundfile directly to avoid the torchcodec dependency introduced
     # in torchaudio >= 2.7, where torchaudio.load() routes all backends
     # through TorchCodec (which requires FFmpeg 5+ not shipped by Ubuntu 22.04).
-    data, sample_rate = sf.read(wav, dtype="float32", always_2d=False)
+    # libsndfile reads from the current cursor position; CosyVoice's frontend
+    # passes the same file-like object to multiple load_wav calls, so reset.
+    if hasattr(wav, 'seek'):
+        wav.seek(0)
+    data, sample_rate = sf.read(wav, dtype='float32', always_2d=False)
     if data.ndim > 1:
         data = data.mean(axis=1)
     speech = torch.from_numpy(data).unsqueeze(0)

--- a/cosyvoice/utils/file_utils.py
+++ b/cosyvoice/utils/file_utils.py
@@ -16,6 +16,7 @@
 
 import os
 import json
+import soundfile as sf
 import torch
 import torchaudio
 import logging
@@ -42,8 +43,13 @@ def read_json_lists(list_file):
 
 
 def load_wav(wav, target_sr, min_sr=16000):
-    speech, sample_rate = torchaudio.load(wav, backend='soundfile')
-    speech = speech.mean(dim=0, keepdim=True)
+    # Use soundfile directly to avoid the torchcodec dependency introduced
+    # in torchaudio >= 2.7, where torchaudio.load() routes all backends
+    # through TorchCodec (which requires FFmpeg 5+ not shipped by Ubuntu 22.04).
+    data, sample_rate = sf.read(wav, dtype="float32", always_2d=False)
+    if data.ndim > 1:
+        data = data.mean(axis=1)
+    speech = torch.from_numpy(data).unsqueeze(0)
     if sample_rate != target_sr:
         assert sample_rate >= min_sr, 'wav sample rate {} must be greater than {}'.format(sample_rate, target_sr)
         speech = torchaudio.transforms.Resample(orig_freq=sample_rate, new_freq=target_sr)(speech)

--- a/cosyvoice/vllm/cosyvoice2.py
+++ b/cosyvoice/vllm/cosyvoice2.py
@@ -23,7 +23,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Inference-only Qwen2 model compatible with HuggingFace weights."""
-from typing import Optional
+from typing import Iterable, Optional, Union
 from packaging.version import parse as vparse
 import vllm
 

--- a/cosyvoice/vllm/cosyvoice2.py
+++ b/cosyvoice/vllm/cosyvoice2.py
@@ -82,6 +82,16 @@ class CosyVoice2ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
     def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.model.get_input_embeddings(input_ids)
 
+    # vLLM >= 0.20 introduced the VllmModelForTextGeneration runtime-checkable
+    # protocol (vllm/model_executor/models/interfaces_base.py). Its
+    # _check_vllm_model_embed_input_ids probe looks for embed_input_ids
+    # specifically; without it, is_text_generation_model() returns False and
+    # ModelConfig validation raises "This model does not support `--runner
+    # generate`". Delegating to the underlying Qwen2Model is the same path as
+    # get_input_embeddings above.
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
+
     def forward(
         self,
         input_ids: torch.Tensor,


### PR DESCRIPTION
- Missing "import from typing" added
- Missing and required method to load a model with vLLM added (i.e., embed_input_ids)
- Removing the dependency of the library from torchaudio when loading the wav data