### PR TITLE
fix: mask all stop_token_ids in sampling_ids + multi-GPU device support

### DIFF
--- a/cosyvoice/cli/frontend.py
+++ b/cosyvoice/cli/frontend.py
@@ -38,7 +38,7 @@ class CosyVoiceFrontEnd:
                  allowed_special: str = 'all'):
         self.tokenizer = get_tokenizer()
         self.feat_extractor = feat_extractor
-        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        self.device = torch.device(f'cuda:{torch.cuda.current_device()}' if torch.cuda.is_available() else torch.device('cpu'))
         option = onnxruntime.SessionOptions()
         option.graph_optimization_level = onnxruntime.GraphOptimizationLevel.ORT_ENABLE_ALL
         option.intra_op_num_threads = 1

--- a/cosyvoice/cli/model.py
+++ b/cosyvoice/cli/model.py
@@ -33,7 +33,7 @@ class CosyVoiceModel:
                  flow: torch.nn.Module,
                  hift: torch.nn.Module,
                  fp16: bool = False):
-        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        self.device = torch.device(f'cuda:{torch.cuda.current_device()}' if torch.cuda.is_available() else torch.device('cpu'))
         self.llm = llm
         self.flow = flow
         self.hift = hift
@@ -249,7 +249,7 @@ class CosyVoice2Model(CosyVoiceModel):
                  flow: torch.nn.Module,
                  hift: torch.nn.Module,
                  fp16: bool = False):
-        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        self.device = torch.device(f'cuda:{torch.cuda.current_device()}' if torch.cuda.is_available() else torch.device('cpu'))
         self.llm = llm
         self.flow = flow
         self.hift = hift
@@ -401,7 +401,7 @@ class CosyVoice3Model(CosyVoice2Model):
                  flow: torch.nn.Module,
                  hift: torch.nn.Module,
                  fp16: bool = False):
-        self.device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+        self.device = torch.device(f'cuda:{torch.cuda.current_device()}' if torch.cuda.is_available() else torch.device('cpu'))
         self.llm = llm
         self.flow = flow
         self.hift = hift

--- a/cosyvoice/llm/llm.py
+++ b/cosyvoice/llm/llm.py
@@ -155,7 +155,11 @@ class TransformerLM(torch.nn.Module):
             ignore_eos: bool = True,
     ):
         if ignore_eos is True:
-            weighted_scores[self.speech_token_size] = -float('inf')
+            if hasattr(self, 'stop_token_ids'):
+                for stop_id in self.stop_token_ids:
+                    weighted_scores[stop_id] = -float('inf')
+            else:
+                weighted_scores[self.speech_token_size] = -float('inf')
         top_ids = self.sampling(weighted_scores, decoded_tokens, sampling)
         return top_ids
 


### PR DESCRIPTION
## Summary

Two bug fixes for CosyVoice3 inference:

1. **`sampling_ids()` only masks `speech_token_size` (sos) during `ignore_eos=True`, not `eos` or other stop tokens** — on certain transformers versions, the LLM can predict EOS with high confidence as the first token, and the unmasked EOS leaks through the `ignore_eos` window, producing garbage output.

2. **Hardcoded `torch.device('cuda')` defaults to `cuda:0`** — on multi-GPU systems, `torch.cuda.set_device()` has no effect and models load on the wrong GPU.

## Changes

### `cosyvoice/llm/llm.py` — sampling_ids fix

`CosyVoice3LM.stop_token_ids = [speech_token_size + i for i in range(200)]` covers sos(6561), eos(6562), task_id(6563), fill_token(6564), etc. The original code only masked index `speech_token_size` (sos=6561), leaving eos(6562) unmasked during the minimum-length window.

This is usually harmless because a well-functioning LLM doesn't predict EOS early. But with slight numerical differences across transformers versions (e.g., SDPA mask handling changed between 4.x and 5.x), the logits can shift enough (~0.012) to flip EOS from #2 to #1, causing the model to output garbage.

The fix uses `hasattr` to maintain backward compatibility with CosyVoice1/2.

### `cosyvoice/cli/model.py` + `cosyvoice/cli/frontend.py` — multi-GPU fix

`torch.device('cuda')` always defaults to `cuda:0`, ignoring `torch.cuda.set_device()`. Changed to `torch.device(f'cuda:{torch.cuda.current_device()}')` in all model classes.

## Testing

Verified with `Fun-CosyVoice3-0.5B-2512`:
- Chinese: "你好世界" → ASR: "你好，世界。" ✅  
- English: "Hello, this is a test." → ASR correct ✅
- Environment: Python 3.11, torch 2.11+cu128, transformers 5.3.0